### PR TITLE
Make Vagrant file work with vagrant 1.3.x

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,8 +68,10 @@ Vagrant.configure("2") do |config|
   # The path to the Berksfile to use with Vagrant Berkshelf
   config.berkshelf.berksfile_path = "./Berksfile"
 
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
+  if Vagrant::VERSION < "1.3.0"
+    config.ssh.max_tries = 40
+    config.ssh.timeout   = 120
+  end
   config.ssh.forward_agent = true
 
   host_project_path = File.expand_path("..", __FILE__)


### PR DESCRIPTION
Vagrant 1.3 removed `ssh.max_tries` and `ssh.timeout` options.
