### PR TITLE
Force yum cookbook to pre 3

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,3 +4,7 @@ cookbook 'omnibus'
 cookbook 'python'
 cookbook 'awscli', git: 'git://github.com/flpjck/awscli'
 
+# Until the upsteam cookbooks have been cleaned up this should be a version prior to 3.
+# http://community.opscode.com/cookbooks/yum
+cookbook "yum", "< 3.0"
+


### PR DESCRIPTION
The change above fixes an issue with the upsteam opscode cookbook dependencies.  Unclear if this is the best/proper fix.
