### PR TITLE
We should allow redis to be accessed outside

### DIFF
--- a/config/software/redis.rb
+++ b/config/software/redis.rb
@@ -17,7 +17,7 @@ config = <<-CONFIG
 daemonize yes
 pidfile /var/run/flapjack/redis-flapjack.pid
 port 6380
-bind 127.0.0.1
+bind 0.0.0.0
 timeout 300
 loglevel notice
 logfile /var/log/flapjack/redis-flapjack.log


### PR DESCRIPTION
Eg if using from a docker container and you want to access redis - this will let you.
