### PR TITLE
Specifiy mixlib shellout 1.6.0 or greater

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'omnibus-software', :github => 'jessereynolds/omnibus-software', :branch => 'omnibus/3.2-stable'
 gem 'omnibus', :github => 'opscode/omnibus', :branch => '3.0-stable'
 gem 'mixlib-log'
-gem 'mixlib-shellout'
+gem 'mixlib-shellout', '>=1.6.0'
 gem 'rake'
 


### PR DESCRIPTION
Using mixlib shellout 1.3.0 which was already installed on my box the rake build would fail with the following.  Looks like 'error?' didn't exist as a method until later.  When I installed mixlib shellout 1.6.0 the 'error?' method is available. 

rake aborted!
undefined method `error?' for #<Mixlib::ShellOut:0x007fb5249b2090>
/Users/derek.olsen/src/omnibus-flapjack/Rakefile:143:in`block in <top (required)>'
/usr/local/Cellar/ruby193/1.9.3-p484/lib/ruby/1.9.1/rake/task.rb:205:in `call'
/usr/local/Cellar/ruby193/1.9.3-p484/lib/ruby/1.9.1/rake/task.rb:205:in`block in execute'
/usr/local/Cellar/ruby193/1.9.3-p484/lib/ruby/1.9.1/rake/task.rb:200:in `each'
/usr/local/Cellar/ruby193/1.9.3-p484/lib/ruby/1.9.1/rake/task.rb:200:in`execute'
