### PR TITLE
Escape backtick's for RPM init script

### DIFF
--- a/dist/etc/init.d/redis-flapjack-rpm.erb
+++ b/dist/etc/init.d/redis-flapjack-rpm.erb
@@ -45,7 +45,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $NAME: "
-    if [ -n "`pgrep $NAME`" ] ; then
+    if [ -n "\`pgrep $NAME\`" ] ; then
         killproc $NAME
     RETVAL=3
     else


### PR DESCRIPTION
Due to the way we write out this file in ruby, the backticks cause the expression to be run during the build step, instead of just passing them through. Escaping these solves things for me.