### PR TITLE
Support building flapjack v2 packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'omnibus-software', :github => 'opscode/omnibus-software'
-gem 'omnibus', :github => 'chef/omnibus', :branch => 'master'
+gem 'omnibus', :github => 'SarahKowalik/omnibus', :branch => 'master'
 gem 'mixlib-log'
 gem 'mixlib-shellout', '>=1.6.1'
 gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'omnibus-software', :github => 'opscode/omnibus-software'
-gem 'omnibus', :github => 'SarahKowalik/omnibus', :branch => 'master'
+gem 'omnibus', :github => 'chef/omnibus', :branch => 'master'
 gem 'mixlib-log'
 gem 'mixlib-shellout', '>=1.6.1'
 gem 'rake'

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The following environment variables affect what `build` does:
 
 - `BUILD_REF`                 - the branch, tag, or commit (on master) to build (Required). If a tag, it'll start with a v if it's a release tag, eg `v1.0.0rc5`
 - `DISTRO`                    - only "ubuntu" is currently supported (Optional, Default: "ubuntu")
-- `DISTRO_RELEASE`            - the release name, eg "precise" (Optional, Default: "trusy")
-- `DRY_RUN`                   - if set, just shows what would be gone (Optional, Default: nil)
+- `DISTRO_RELEASE`            - the release name, eg "precise" (Optional, Default: "trusty")
+- `DRY_RUN`                   - if set, just shows what would be done (Optional, Default: nil)
 - `OFFICIAL_FLAPJACK_PACKAGE` - if true, signs built packages, assuming that the Flapjack Signing Key is on the system
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -81,7 +81,7 @@ task :build do
     end
   end
 
-  omnibus_cmd = OmnibusFlapjack::Helpers.build_omnibus_cmd(pkg)
+  omnibus_cmd = "locale-gen en_US.UTF-8 && " + OmnibusFlapjack::Helpers.build_omnibus_cmd(pkg)
 
   container_name = "flapjack-build-#{pkg.distro_release}"
 
@@ -91,6 +91,9 @@ task :build do
     '--attach', 'stderr',
     '--detach=false',
     '--name', container_name,
+    '-e', 'LANG=en_US.UTF-8',
+    '-e', 'LANGUAGE=en_US:en',
+    '-e', 'LC_ALL=en_US.UTF-8',
     '-e', "FLAPJACK_BUILD_REF=#{pkg.build_ref}",
     '-e', "FLAPJACK_EXPERIMENTAL_PACKAGE_VERSION=#{pkg.experimental_package_version}",
     '-e', "FLAPJACK_MAIN_PACKAGE_VERSION=#{pkg.main_package_version}",

--- a/Rakefile
+++ b/Rakefile
@@ -81,7 +81,12 @@ task :build do
     end
   end
 
-  omnibus_cmd = "locale-gen en_US.UTF-8 && " + OmnibusFlapjack::Helpers.build_omnibus_cmd(pkg)
+  # can't set locale before it's generated :(
+  omnibus_cmd = "locale-gen en_US.UTF-8 && "  \
+                "export LANG=en_US.UTF-8 && " \
+                "export LC_ALL=en_US.UTF-8 && " \
+                "export LANGUAGE=en_US:en && " +
+                OmnibusFlapjack::Helpers.build_omnibus_cmd(pkg)
 
   container_name = "flapjack-build-#{pkg.distro_release}"
 
@@ -91,9 +96,6 @@ task :build do
     '--attach', 'stderr',
     '--detach=false',
     '--name', container_name,
-    '-e', 'LANG=en_US.UTF-8',
-    '-e', 'LANGUAGE=en_US:en',
-    '-e', 'LC_ALL=en_US.UTF-8',
     '-e', "FLAPJACK_BUILD_REF=#{pkg.build_ref}",
     '-e', "FLAPJACK_EXPERIMENTAL_PACKAGE_VERSION=#{pkg.experimental_package_version}",
     '-e', "FLAPJACK_MAIN_PACKAGE_VERSION=#{pkg.main_package_version}",

--- a/config/projects/flapjack-dependencies.rb
+++ b/config/projects/flapjack-dependencies.rb
@@ -1,19 +1,22 @@
-
 name          "flapjack-dependencies"
 friendly_name "Flapjack's Dependencies"
 maintainer    "Lindsay Holmwood, Jesse Reynolds, Ali Graham, Sarah Kowalik"
 homepage      "http://flapjack.io"
+
+package_version = ENV['FLAPJACK_EXPERIMENTAL_PACKAGE_VERSION']
+raise "FLAPJACK_EXPERIMENTAL_PACKAGE_VERSION must be set" unless package_version
 
 install_dir   "/opt/flapjack"
 
 build_version  "#{Time.now.strftime('%Y%m%d%H%M%S')}"
 build_iteration 1
 
+depend_nokogiri_etc = !(/^(?:0\.9\.|1\.)/.match(package_version).nil?)
+
 # creates required build directories
 dependency "preparation"
 
 # flapjack dependencies/components
-# dependency "somedep"
 
 # version manifest file
 dependency "version-manifest"
@@ -28,7 +31,10 @@ dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "redis"
-# dependency "yajl"
-# dependency "zlib"
-# dependency "nokogiri"
 
+if depend_nokogiri_etc
+  # Flapjack pre-v2 dependencies
+  dependency "yajl"
+  dependency "zlib"
+  dependency "nokogiri"
+end

--- a/config/projects/flapjack-dependencies.rb
+++ b/config/projects/flapjack-dependencies.rb
@@ -21,13 +21,13 @@ dependency "version-manifest"
 exclude "\.git*"
 exclude "bundler\/git"
 
-override :ruby, version: '2.1.2'
+override :ruby, version: '2.2.2'
 
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "redis"
-dependency "yajl"
-dependency "zlib"
-dependency "nokogiri"
+# dependency "yajl"
+# dependency "zlib"
+# dependency "nokogiri"
 

--- a/config/projects/flapjack-dependencies.rb
+++ b/config/projects/flapjack-dependencies.rb
@@ -21,7 +21,7 @@ dependency "version-manifest"
 exclude "\.git*"
 exclude "bundler\/git"
 
-override :ruby, version: '2.2.2'
+override :ruby, version: '2.2.3'
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/projects/flapjack-dependencies.rb
+++ b/config/projects/flapjack-dependencies.rb
@@ -22,6 +22,7 @@ exclude "\.git*"
 exclude "bundler\/git"
 
 override :ruby, version: '2.2.3'
+override :rubygems, version: '2.4.8'
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/projects/flapjack.rb
+++ b/config/projects/flapjack.rb
@@ -22,6 +22,8 @@ raise "FLAPJACK_EXPERIMENTAL_PACKAGE_VERSION must be set" unless package_version
 build_version package_version
 build_iteration 1
 
+depend_nokogiri_etc = !(/^(?:0\.9\.|1\.)/.match(package_version).nil?)
+
 # creates required build directories
 dependency "preparation"
 
@@ -41,7 +43,12 @@ dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "redis"
-# dependency "yajl"
-# dependency "zlib"
-# dependency "nokogiri"
+
+if depend_nokogiri_etc
+  # Flapjack pre-v2 dependencies
+  dependency "yajl"
+  dependency "zlib"
+  dependency "nokogiri"
+end
+
 dependency "flapjack"

--- a/config/projects/flapjack.rb
+++ b/config/projects/flapjack.rb
@@ -35,6 +35,7 @@ exclude "\.git*"
 exclude "bundler\/git"
 
 override :ruby, version: '2.2.3'
+override :rubygems, version: '2.4.8'
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/projects/flapjack.rb
+++ b/config/projects/flapjack.rb
@@ -34,7 +34,7 @@ dependency "version-manifest"
 exclude "\.git*"
 exclude "bundler\/git"
 
-override :ruby, version: '2.2.2'
+override :ruby, version: '2.2.3'
 
 dependency "ruby"
 dependency "rubygems"

--- a/config/projects/flapjack.rb
+++ b/config/projects/flapjack.rb
@@ -34,13 +34,13 @@ dependency "version-manifest"
 exclude "\.git*"
 exclude "bundler\/git"
 
-override :ruby, version: '2.1.2'
+override :ruby, version: '2.2.2'
 
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 dependency "redis"
-dependency "yajl"
-dependency "zlib"
-dependency "nokogiri"
+# dependency "yajl"
+# dependency "zlib"
+# dependency "nokogiri"
 dependency "flapjack"

--- a/config/software/flapjack.rb
+++ b/config/software/flapjack.rb
@@ -8,12 +8,15 @@ raise "FLAPJACK_EXPERIMENTAL_PACKAGE_VERSION must be set" unless package_version
 
 default_version package_version
 
-compile_go_components = package_version =~ /^0\.9\./ ? false : true
+compile_go_components = /^0\.9\./.match(package_version).nil?
+depend_nokogiri = !(/^(?:0\.9\.|1\.)/.match(package_version).nil?)
 
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
-# dependency "nokogiri"
+if depend_nokogiri
+  dependency "nokogiri"
+end
 
 relative_path "flapjack"
 

--- a/config/software/flapjack.rb
+++ b/config/software/flapjack.rb
@@ -22,45 +22,39 @@ omnibus_flapjack_path = Dir.pwd
 
 build do
   command "if [ ! -d flapjack_source ] ; then git clone https://github.com/flapjack/flapjack.git flapjack_source ; fi"
-  command "cd flapjack_source && " +
-          "git checkout master && " +
-          "git pull && " +
-          "git checkout #{build_ref} && " +
+  command "cd flapjack_source && " \
+          "git checkout master && " \
+          "git pull && " \
+          "git checkout #{build_ref} && " \
           "/opt/flapjack/embedded/bin/gem build flapjack.gemspec"
   gem [ "install /var/cache/omnibus/src/flapjack/flapjack_source/flapjack*gem",
         "--bindir #{install_dir}/bin",
         "--no-rdoc --no-ri" ].join(" ")
 
-  command "export gem_home=/" +
-          "`/opt/flapjack/embedded/bin/gem list --all --details flapjack | " +
-          "  grep 'Installed at' | sed 's/^.* \\///'` ; " +
-          "echo \"gem_home: ${gem_home}\" ; " +
-          "export installed_gem=`ls -dtr ${gem_home}/gems/flapjack* | tail -1` ; " +
+  command "export gem_home=\"`/opt/flapjack/embedded/bin/gem environment gemdir`\" ; " \
+          "echo \"gem_home: ${gem_home}\" ; " \
+          "export installed_gem=\"`ls -dtr ${gem_home}/gems/flapjack* | tail -1`\" ; " \
           "cd ${installed_gem}"
   if compile_go_components
-    command "export gem_home=/" +
-      "`/opt/flapjack/embedded/bin/gem list --all --details flapjack | " +
-      "  grep 'Installed at' | sed 's/^.* \\///'` ; " +
-      "echo \"gem_home: ${gem_home}\" ; " +
-      "export installed_gem=`ls -dtr ${gem_home}/gems/flapjack* | tail -1` ; " +
-      "cd ${installed_gem} && " +
-      "./build.sh"
+    command "export gem_home=\"`/opt/flapjack/embedded/bin/gem environment gemdir`\" ; " \
+            "echo \"gem_home: ${gem_home}\" ; " \
+            "export installed_gem=\"`ls -dtr ${gem_home}/gems/flapjack* | tail -1`\" ; " \
+            "cd ${installed_gem} && " \
+            "./build.sh"
   end
 
   # Build flapjackfeeder, as per https://github.com/flapjack/flapjackfeeder
-  command "export gem_home=/" +
-    "`/opt/flapjack/embedded/bin/gem list --all --details flapjack | " +
-    "  grep 'Installed at' | sed 's/^.* \\///'` ; " +
-    "echo \"gem_home: ${gem_home}\" ; " +
-    "export installed_gem=`ls -dtr ${gem_home}/gems/flapjack* | tail -1` ; " +
-    "cd ${installed_gem} && " +
-    "if [ ! -d flapjackfeeder ] ; then git clone https://github.com/flapjack/flapjackfeeder.git flapjackfeeder ; fi && " +
-    "cd flapjackfeeder && " +
-    "make && " +
-    "cd .. && " +
-    "cp flapjackfeeder/flapjackfeeder3-*.o flapjackfeeder3.o && " +
-    "cp flapjackfeeder/flapjackfeeder4-*.o flapjackfeeder4.o && " +
-    "rm -r flapjackfeeder"
+  command "export gem_home=\"`/opt/flapjack/embedded/bin/gem environment gemdir`\" ; " \
+          "echo \"gem_home: ${gem_home}\" ; " \
+          "export installed_gem=\"`ls -dtr ${gem_home}/gems/flapjack* | tail -1`\" ; " \
+          "cd ${installed_gem} && " \
+          "if [ ! -d flapjackfeeder ] ; then git clone https://github.com/flapjack/flapjackfeeder.git flapjackfeeder ; fi && " \
+          "cd flapjackfeeder && " \
+          "make && " \
+          "cd .. && " \
+          "cp flapjackfeeder/flapjackfeeder3-*.o flapjackfeeder3.o && " \
+          "cp flapjackfeeder/flapjackfeeder4-*.o flapjackfeeder4.o && " \
+          "rm -r flapjackfeeder"
 
     command "cp #{omnibus_flapjack_path}/dist/etc/init.d/flapjack* #{etc_path}/init.d/"
     command "cp #{omnibus_flapjack_path}/dist/etc/init.d/flapper* #{etc_path}/init.d/"

--- a/config/software/flapjack.rb
+++ b/config/software/flapjack.rb
@@ -13,7 +13,7 @@ compile_go_components = package_version =~ /^0\.9\./ ? false : true
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
-dependency "nokogiri"
+# dependency "nokogiri"
 
 relative_path "flapjack"
 

--- a/lib/omnibus-flapjack/helpers.rb
+++ b/lib/omnibus-flapjack/helpers.rb
@@ -58,12 +58,15 @@ module OmnibusFlapjack
     end
 
     def self.build_omnibus_cmd(pkg)
+      # ensure current branch is used, whether or not that's master
+      current_commit = `git log --pretty=format:'%H' -n 1`.strip
+
       omnibus_cmd = [
         "if [[ -f /opt/rh/ruby193/enable ]]; then source /opt/rh/ruby193/enable; fi",
         "export PATH=$PATH:/usr/local/go/bin",
         "cd omnibus-flapjack",
         "git pull",
-        "git checkout v2_package_wip",
+        "git checkout #{current_commit}",
         "cp .rpmmacros ~/.rpmmacros",
         "bundle update omnibus",
         "bundle update omnibus-software",
@@ -137,7 +140,7 @@ module OmnibusFlapjack
 
     def self.run_tests_in_docker(options)
       # The test commands are split into three parts:
-      # Setup command: Sets up the pre-requiste packages for testing, including the correct version of ruby (different for each OS)
+      # Setup command: Sets up the pre-requisite packages for testing, including the correct version of ruby (different for each OS)
       # Install command: Installs Flapjack, either from puppet or from a package on the file system
       # Test command: Runs the tests (identical across OSes)
       case options[:distro]

--- a/lib/omnibus-flapjack/helpers.rb
+++ b/lib/omnibus-flapjack/helpers.rb
@@ -63,6 +63,7 @@ module OmnibusFlapjack
         "export PATH=$PATH:/usr/local/go/bin",
         "cd omnibus-flapjack",
         "git pull",
+        "git checkout v2_package_wip",
         "cp .rpmmacros ~/.rpmmacros",
         "bundle update omnibus",
         "bundle update omnibus-software",

--- a/lib/omnibus-flapjack/package.rb
+++ b/lib/omnibus-flapjack/package.rb
@@ -153,7 +153,7 @@ module OmnibusFlapjack
       @experimental_package_version ||= if truth_from_filename
         package_version
       else
-        first, second = version.match(/^([0-9.]*)-?([a-z0-9.]*)$/).captures
+        first, second = version.match(/^([0-9.]*)([a-z0-9.]*)$/).captures
         case @distro
         when 'ubuntu', 'debian'
           build_ref_clean = build_ref.sub(/\//, '.')

--- a/lib/omnibus-flapjack/package.rb
+++ b/lib/omnibus-flapjack/package.rb
@@ -74,12 +74,13 @@ module OmnibusFlapjack
           "#{simple_version}#{addendum}"
         end
       else
-        version_url = "https://raw.githubusercontent.com/flapjack/flapjack/" +
+        version_url = "https://raw.githubusercontent.com/flapjack/flapjack/" \
                       "#{build_ref}/lib/flapjack/version.rb"
         open(version_url) {|f|
           f.each_line {|line|
-            next unless line =~ /VERSION.*=.*'(.+)'/
-            @version = $1
+            # allow either single or double quotes, handle escaped quotes
+            next unless line =~ /VERSION.*=.*(?:"([^"\\]*(?:\\.[^"\\]*)*)"|\'([^\'\\]*(?:\\.[^\'\\]*)*)\')/
+            @version = $1 || $2
           }
         }
         if @version.nil? || @version.empty?

--- a/lib/omnibus-flapjack/package.rb
+++ b/lib/omnibus-flapjack/package.rb
@@ -78,11 +78,11 @@ module OmnibusFlapjack
                       "#{build_ref}/lib/flapjack/version.rb"
         open(version_url) {|f|
           f.each_line {|line|
-            next unless line =~ /VERSION.*=.*"(.*)"/
+            next unless line =~ /VERSION.*=.*'(.+)'/
             @version = $1
           }
         }
-        unless version.length > 0
+        if @version.nil? || @version.empty?
           raise "Incorrect build_ref.  Tags should be specified as 'v1.0.0rc3'"
         end
         @version
@@ -153,7 +153,7 @@ module OmnibusFlapjack
       @experimental_package_version ||= if truth_from_filename
         package_version
       else
-        first, second = version.match(/^([0-9.]*)([a-z0-9.]*)$/).captures
+        first, second = version.match(/^([0-9.]*)-?([a-z0-9.]*)$/).captures
         case @distro
         when 'ubuntu', 'debian'
           build_ref_clean = build_ref.sub(/\//, '.')


### PR DESCRIPTION
I've used this to successfully build Debian packages (for precise) of both v1.6.0 and [current flapjack master](https://github.com/flapjack/flapjack/commit/47cd2a4592fed62ae41aed7c976045466d911e08), haven't touched publishing or tried any other package types/distribution versions.

The locale changes fix #104.

The checkout of the commit the build is run from is a bit hacky, but at least supports development in branches.

The rest of the changes concern differences between Flapjack v1 and v2 requirements, version number line format, etc.

It uses latest Rubygems and Ruby offered by `omnibus-software` at time of writing; I'd like to get things using the most recent `chef/omnibus` version, but went some way down that path and decided it was mostly irrelevant to the core purpose of this PR, which was to get v2 packages building with the current tools. I'll work on that for another pull request.